### PR TITLE
Benchmarking

### DIFF
--- a/benchmark/bench_tfphasespace.py
+++ b/benchmark/bench_tfphasespace.py
@@ -15,7 +15,7 @@ import os, sys
 
 sys.path.append(os.path.dirname(__file__))
 
-from .monitoring import Timer
+from monitoring import Timer
 
 # to play around with optimization, no big effect though
 NUM_PARALLEL_EXEC_UNITS = 1
@@ -26,17 +26,15 @@ B_MASS = 5279.0
 B_AT_REST = tf.stack((0.0, 0.0, 0.0, B_MASS), axis=-1)
 PION_MASS = 139.6
 
-N_EVENTS = 1000000
-CHUNK_SIZE = N_EVENTS
+N_EVENTS = 100000000
+CHUNK_SIZE = 1000000
 
 N_EVENTS_VAR = tf.Variable(initial_value=N_EVENTS)
 CHUNK_SIZE_VAR = tf.Variable(initial_value=CHUNK_SIZE)
 
 samples = [tfphasespace.generate(B_AT_REST,
                                  [PION_MASS, PION_MASS, PION_MASS],
-                                 CHUNK_SIZE_VAR)
-           for _ in range(0, N_EVENTS, CHUNK_SIZE)
-           ]
+                                 CHUNK_SIZE_VAR)] * int(N_EVENTS / CHUNK_SIZE)
 
 sess = tf.Session(
         config=config

--- a/benchmark/bench_tgenphasespace.cxx
+++ b/benchmark/bench_tgenphasespace.cxx
@@ -5,7 +5,7 @@
 #include "TLorentzVector.h"
 #include "TGenPhaseSpace.h"
 
-Int_t N_EVENTS = 1000000;
+Int_t N_EVENTS = 100000000;
 
 int bench_tgenphasespace()
 {


### PR DESCRIPTION
First try at serious benchmarking.

Still, we're quite slow, also because creating multiple graphs takes a long time (total time is 202 seconds!):

```shell
(zfit36) [10:34]farm-gpu:~/zfit/tfphasespace/benchmark[benchmarks]$ CUDA_VISIBLE_DEVICES= python3 bench_tfphasespace.py
2019-03-12 10:35:18.778705: I tensorflow/core/platform/cpu_feature_guard.cc:141] Your CPU supports instructions that this TensorFlow binary was not compiled to use: SSE4.1 SSE4.2 AVX AVX2 FMA
2019-03-12 10:35:19.994733: E tensorflow/stream_executor/cuda/cuda_driver.cc:300] failed call to cuInit: CUDA_ERROR_NO_DEVICE: no CUDA-capable device is detected
2019-03-12 10:35:19.994797: I tensorflow/stream_executor/cuda/cuda_diagnostics.cc:163] retrieving CUDA diagnostic information for host: farm-gpu
2019-03-12 10:35:19.994807: I tensorflow/stream_executor/cuda/cuda_diagnostics.cc:170] hostname: farm-gpu
2019-03-12 10:35:19.994851: I tensorflow/stream_executor/cuda/cuda_diagnostics.cc:194] libcuda reported version is: 410.78.0
2019-03-12 10:35:19.994891: I tensorflow/stream_executor/cuda/cuda_diagnostics.cc:198] kernel reported version is: 410.78.0
2019-03-12 10:35:19.994900: I tensorflow/stream_executor/cuda/cuda_diagnostics.cc:305] kernel version seems to match DSO: 410.78.0
Initial run (may takes more time than consequent runs)
Elapsed time: 93251.58056803048 ms
starting benchmark
Total number of generated samples 100000100
Shape of one particle momentum (4, 1000001)
Elapsed time: 70495.63611880876 ms
Time per sample: 7.049556562324313e-07 ms
CUDA_VISIBLE_DEVICES= python3 bench_tfphasespace.py  202.81s user 12.83s system 99% cpu 3:37.76 total
```

vs

```shell
(zfit36) [10:38]farm-gpu:~/zfit/tfphasespace/benchmark[benchmarks]$ root -q bench_tgenphasespace.cxx+

Processing bench_tgenphasespace.cxx+...
(int) 0
root -l -q bench_tgenphasespace.cxx+  26.52s user 0.11s system 97% cpu 27.206 total
```
