### PR TITLE
build: support TensorFlow 2.5 and Python 3.9

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.6, 3.7, 3.8 ]
+        python-version: [ 3.6, 3.7, 3.8, 3.9 ]
 
     steps:
       - uses: actions/checkout@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - 3.6
   - 3.7
   - 3.8
+  - 3.9
 
 cache: pip
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-tensorflow>=2.3
+tensorflow>=2.3,<2.6
 tensorflow_probability>=0.11,<0.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-tensorflow>=2.3,<2.5
+tensorflow>=2.3
 tensorflow_probability>=0.11,<0.13

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Topic :: Scientific/Engineering :: Physics
 
 [options]


### PR DESCRIPTION
Hi @mayou36, it seems that `phasespace` can safely update to tensorflow 2.5. (There only seem to be problems with `test_physics.py`, but seems that was already there due to uproot.)

Should anything else be changed?