### PR TITLE
feat!: enable switching between numpy and TF

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,5 @@ jobs:
         run: PHASESPACE_EAGER=0 pytest --basetemp={envtmpdir}
       - name: Test with pytest (eager mode)
         run: PHASESPACE_EAGER=1 pytest --basetemp={envtmpdir}
+      - name: Test with pytest (NumPy backend)
+        run: PHASESPACE_BACKEND=NUMPY pytest --basetemp={envtmpdir}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,6 @@ import sys
 sys.path.insert(0, os.path.abspath(".."))
 
 import sphinx_bootstrap_theme
-import tensorflow as tf
 
 import phasespace
 

--- a/phasespace/__init__.py
+++ b/phasespace/__init__.py
@@ -6,21 +6,15 @@ __email__ = "apuignav@gmail.com"
 __version__ = get_distribution(__name__).version
 __maintainer__ = "zfit"
 
-__credits__ = ["Jonas Eschle <Jonas.Eschle@cern.ch>"]
+__credits__ = [
+    "Jonas Eschle <Jonas.Eschle@cern.ch>",
+]
 
-__all__ = ["nbody_decay", "GenParticle", "random"]
-
-import tensorflow as tf
-
-
-def _set_eager_mode():
-    import os
-
-    is_eager = bool(os.environ.get("PHASESPACE_EAGER"))
-    tf.config.run_functions_eagerly(is_eager)
-
-
-_set_eager_mode()
+__all__ = [
+    "GenParticle",
+    "nbody_decay",
+    "random",
+]
 
 from . import random
 from .phasespace import GenParticle, nbody_decay

--- a/phasespace/backend.py
+++ b/phasespace/backend.py
@@ -1,21 +1,48 @@
-import tensorflow as tf
+import os
+from enum import Enum, auto
 
-RELAX_SHAPES = True
-if int(tf.__version__.split(".")[1]) < 5:  # smaller than 2.5
-    jit_compile_argname = "experimental_compile"
-else:
-    jit_compile_argname = "jit_compile"
-function = tf.function(
-    autograph=False,
-    experimental_relax_shapes=RELAX_SHAPES,
-    **{jit_compile_argname: False}
-)
-function_jit = tf.function(
-    autograph=False,
-    experimental_relax_shapes=RELAX_SHAPES,
-    **{jit_compile_argname: True}
-)
+__all__ = [
+    "function",
+    "function_jit",
+    "function_jit_fixedshape",
+    "tnp",
+]
 
-function_jit_fixedshape = tf.function(
-    autograph=False, experimental_relax_shapes=False, **{jit_compile_argname: True}
-)
+
+class BackendType(Enum):
+    TENSORFLOW = auto()
+
+    @staticmethod
+    def get_backend(backend: str) -> "BackendType":
+        backend_formatted = backend.lower().strip()
+        if backend_formatted in {"", "tf", "tensorflow"}:
+            return BackendType.TENSORFLOW
+        raise NotImplementedError(f'No backend implemented for "{backend}"')
+
+
+BACKEND = BackendType.get_backend(os.environ.get("PHASESPACE_BACKEND", ""))
+if BACKEND == BackendType.TENSORFLOW:
+    import tensorflow as tf
+    import tensorflow.experimental.numpy as tnp
+
+    if int(tf.__version__.split(".")[1]) < 5:  # smaller than 2.5
+        jit_compile_argname = "experimental_compile"
+    else:
+        jit_compile_argname = "jit_compile"
+    function = tf.function(
+        autograph=False,
+        experimental_relax_shapes=True,
+        **{jit_compile_argname: False},
+    )
+    function_jit = tf.function(
+        autograph=False,
+        experimental_relax_shapes=True,
+        **{jit_compile_argname: True},
+    )
+    function_jit_fixedshape = tf.function(
+        autograph=False,
+        experimental_relax_shapes=False,
+        **{jit_compile_argname: True},
+    )
+    is_eager = bool(os.environ.get("PHASESPACE_EAGER"))
+    tf.config.run_functions_eagerly(is_eager)

--- a/phasespace/backend/__init__.py
+++ b/phasespace/backend/__init__.py
@@ -13,10 +13,13 @@ __all__ = [
 
 class BackendType(Enum):
     TENSORFLOW = auto()
+    NUMPY = auto()
 
     @staticmethod
     def get_backend(backend: str) -> "BackendType":
         backend_formatted = backend.lower().strip()
+        if backend_formatted in {"np", "numpy"}:
+            return BackendType.NUMPY
         if backend_formatted in {"", "tf", "tensorflow"}:
             return BackendType.TENSORFLOW
         raise NotImplementedError(f'No backend implemented for "{backend}"')
@@ -57,3 +60,22 @@ if BACKEND == BackendType.TENSORFLOW:
 
     is_eager = bool(os.environ.get("PHASESPACE_EAGER"))
     tf.config.run_functions_eagerly(is_eager)
+
+if BACKEND == BackendType.NUMPY:
+    import numpy as tnp
+
+    from . import _np_random as random
+
+    function = lambda x: x
+    function_jit = lambda x: x
+    function_jit_fixedshape = lambda x: x
+
+    Tensor = tnp.ndarray
+    Variable = tnp.ndarray
+    get_shape = tnp.shape
+
+    def assert_equal(x, y, message: str, name: str = "") -> None:
+        return tnp.testing.assert_equal(x, y, err_msg=message)
+
+    def assert_greater_equal(x, y, message: str, name: str = "") -> None:
+        return tnp.testing.assert_array_less(-x, -y, err_msg=message)

--- a/phasespace/backend/__init__.py
+++ b/phasespace/backend/__init__.py
@@ -5,6 +5,7 @@ __all__ = [
     "function",
     "function_jit",
     "function_jit_fixedshape",
+    "get_shape",
     "random",
     "tnp",
 ]
@@ -47,5 +48,8 @@ if BACKEND == BackendType.TENSORFLOW:
         experimental_relax_shapes=False,
         **{jit_compile_argname: True},
     )
+
+    get_shape = tf.shape  # get shape dynamically
+
     is_eager = bool(os.environ.get("PHASESPACE_EAGER"))
     tf.config.run_functions_eagerly(is_eager)

--- a/phasespace/backend/__init__.py
+++ b/phasespace/backend/__init__.py
@@ -18,9 +18,9 @@ class BackendType(Enum):
     @staticmethod
     def get_backend(backend: str) -> "BackendType":
         backend_formatted = backend.lower().strip()
-        if backend_formatted in {"np", "numpy"}:
+        if backend_formatted in {"", "np", "numpy"}:
             return BackendType.NUMPY
-        if backend_formatted in {"", "tf", "tensorflow"}:
+        if backend_formatted in {"tf", "tensorflow"}:
             return BackendType.TENSORFLOW
         raise NotImplementedError(f'No backend implemented for "{backend}"')
 

--- a/phasespace/backend/__init__.py
+++ b/phasespace/backend/__init__.py
@@ -50,6 +50,8 @@ if BACKEND == BackendType.TENSORFLOW:
     )
 
     get_shape = tf.shape  # get shape dynamically
+    assert_equal = tf.assert_equal
+    assert_greater_equal = tf.debugging.assert_greater_equal
 
     is_eager = bool(os.environ.get("PHASESPACE_EAGER"))
     tf.config.run_functions_eagerly(is_eager)

--- a/phasespace/backend/__init__.py
+++ b/phasespace/backend/__init__.py
@@ -49,6 +49,8 @@ if BACKEND == BackendType.TENSORFLOW:
         **{jit_compile_argname: True},
     )
 
+    Tensor = tf.Tensor
+    Variable = tf.Variable
     get_shape = tf.shape  # get shape dynamically
     assert_equal = tf.assert_equal
     assert_greater_equal = tf.debugging.assert_greater_equal

--- a/phasespace/backend/__init__.py
+++ b/phasespace/backend/__init__.py
@@ -27,7 +27,15 @@ class BackendType(Enum):
 
 BACKEND = BackendType.get_backend(os.environ.get("PHASESPACE_BACKEND", ""))
 if BACKEND == BackendType.TENSORFLOW:
-    import tensorflow as tf
+    try:
+        import tensorflow as tf
+    except ImportError:
+        message = """
+To use phasespace with tensorflow as backend, please reinstall with:
+
+    pip install phasespace[tf]
+"""
+        raise ImportError(message)
     import tensorflow.experimental.numpy as tnp
 
     from . import _tf_random as random

--- a/phasespace/backend/__init__.py
+++ b/phasespace/backend/__init__.py
@@ -5,6 +5,7 @@ __all__ = [
     "function",
     "function_jit",
     "function_jit_fixedshape",
+    "random",
     "tnp",
 ]
 
@@ -24,6 +25,8 @@ BACKEND = BackendType.get_backend(os.environ.get("PHASESPACE_BACKEND", ""))
 if BACKEND == BackendType.TENSORFLOW:
     import tensorflow as tf
     import tensorflow.experimental.numpy as tnp
+
+    from . import _tf_random as random
 
     if int(tf.__version__.split(".")[1]) < 5:  # smaller than 2.5
         jit_compile_argname = "experimental_compile"

--- a/phasespace/backend/_np_random.py
+++ b/phasespace/backend/_np_random.py
@@ -1,0 +1,20 @@
+__all__ = [
+    "Generator",
+    "from_seed",
+    "default_rng",
+]
+
+from typing import Optional, Type
+
+from numpy.random import PCG64, BitGenerator, Generator, default_rng
+
+
+def from_seed(
+    seed,
+    alg: Optional[Type[BitGenerator]] = None,
+) -> Generator:
+    """Function that mimicks `tf.random.Generator.from_seed`."""
+    if alg is None:
+        alg = PCG64
+    bit_generator = alg(seed)
+    return Generator(bit_generator)

--- a/phasespace/backend/_tf_random.py
+++ b/phasespace/backend/_tf_random.py
@@ -1,0 +1,7 @@
+__all__ = [
+    "Generator",
+    "default_rng",
+]
+
+from tensorflow.random import Generator
+from tensorflow.random import get_global_generator as default_rng

--- a/phasespace/backend/_tf_random.py
+++ b/phasespace/backend/_tf_random.py
@@ -1,7 +1,10 @@
 __all__ = [
     "Generator",
+    "from_seed",
     "default_rng",
 ]
 
 from tensorflow.random import Generator
 from tensorflow.random import get_global_generator as default_rng
+
+from_seed = Generator.from_seed

--- a/phasespace/kinematics.py
+++ b/phasespace/kinematics.py
@@ -6,9 +6,7 @@
 # =============================================================================
 """Basic kinematics."""
 
-import tensorflow.experimental.numpy as tnp
-
-from phasespace.backend import function, function_jit
+from phasespace.backend import function, function_jit, tnp
 
 
 @function_jit

--- a/phasespace/phasespace.py
+++ b/phasespace/phasespace.py
@@ -14,7 +14,14 @@ import inspect
 import warnings
 
 from . import kinematics as kin
-from .backend import function, function_jit_fixedshape, get_shape, tnp
+from .backend import (
+    assert_equal,
+    assert_greater_equal,
+    function,
+    function_jit_fixedshape,
+    get_shape,
+    tnp,
+)
 from .random import SeedLike, generate_uniform, get_rng
 
 RELAX_SHAPES = False
@@ -253,7 +260,7 @@ class GenParticle:
                     momentum_shape = tnp.asarray(momentum_shape, tnp.int64)
                 else:
                     momentum_shape = tnp.asarray(momentum_shape, dtype=tnp.int64)
-                tf.assert_equal(
+                assert_equal(
                     n_events,
                     momentum_shape,
                     message="Conflicting inputs -> momentum_shape and n_events",
@@ -342,7 +349,7 @@ class GenParticle:
         # if len(masses.shape) == 1:
         #     masses = tnp.expand_dims(masses, axis=0)
         available_mass = top_mass - tnp.sum(masses, axis=1, keepdims=True)
-        tf.debugging.assert_greater_equal(
+        assert_greater_equal(
             available_mass,
             tnp.zeros_like(available_mass, dtype=tnp.float64),
             message="Forbidden decay",
@@ -658,7 +665,7 @@ class GenParticle:
                 f"The number of events requested ({n_events}) doesn't match the boost_to input size "
                 f"of {boost_to.shape}"
             )
-            tf.assert_equal(len(boost_to), n_events, message=message)
+            assert_equal(len(boost_to), n_events, message=message)
         if not isinstance(n_events, tf.Variable):
             n_events = tnp.asarray(n_events, dtype=tnp.int64)
         weights, weights_max, parts, _ = self._recursive_generate(

--- a/phasespace/phasespace.py
+++ b/phasespace/phasespace.py
@@ -22,7 +22,8 @@ from math import pi
 from typing import Callable, Dict, Optional, Tuple, Union
 
 import tensorflow as tf
-import tensorflow.experimental.numpy as tnp
+
+from phasespace.backend import tnp
 
 from . import kinematics as kin
 

--- a/phasespace/phasespace.py
+++ b/phasespace/phasespace.py
@@ -14,7 +14,7 @@ import inspect
 import warnings
 
 from .backend import function, function_jit_fixedshape
-from .random import SeedLike, get_rng
+from .random import SeedLike, generate_uniform, get_rng
 
 RELAX_SHAPES = False
 
@@ -350,7 +350,7 @@ class GenParticle:
         w_max = self._get_w_max(available_mass, masses)
         p_top_boost = kin.boost_components(p_top)
         # Start the generation
-        random_numbers = rng.uniform((n_events, n_particles - 2), dtype=tnp.float64)
+        random_numbers = generate_uniform(rng, shape=(n_events, n_particles - 2))
         random = tnp.concatenate(
             [
                 tnp.zeros((n_events, 1), dtype=tnp.float64),
@@ -427,14 +427,14 @@ class GenParticle:
                 )
             )
 
-            cos_z = tnp.asarray(2.0, dtype=tnp.float64) * rng.uniform(
-                (n_events, 1), dtype=tnp.float64
+            cos_z = tnp.asarray(2.0, dtype=tnp.float64) * generate_uniform(
+                rng, shape=(n_events, 1)
             ) - tnp.asarray(1.0, dtype=tnp.float64)
             sin_z = tnp.sqrt(tnp.asarray(1.0, dtype=tnp.float64) - cos_z * cos_z)
             ang_y = (
                 tnp.asarray(2.0, dtype=tnp.float64)
                 * tnp.asarray(pi, dtype=tnp.float64)
-                * rng.uniform((n_events, 1), dtype=tnp.float64)
+                * generate_uniform(rng, shape=(n_events, 1))
             )
             cos_y = tnp.cos(ang_y)
             sin_y = tnp.sin(ang_y)

--- a/phasespace/phasespace.py
+++ b/phasespace/phasespace.py
@@ -31,11 +31,11 @@ RELAX_SHAPES = False
 from math import pi
 from typing import Callable, Dict, Optional, Tuple, Union
 
-import tensorflow as tf
-
-from phasespace.backend import tnp
-
-from . import kinematics as kin
+try:
+    from tensorflow import Tensor, Variable
+except ImportError:
+    Tensor = tnp.ndarray
+    Variable = tnp.ndarray
 
 
 def process_list_to_tensor(lst):
@@ -108,9 +108,7 @@ class GenParticle:
         if not callable(mass) and not isinstance(mass, Variable):
             mass = tnp.asarray(mass, dtype=tnp.float64)
         else:
-            mass = tf.function(
-                mass, autograph=False, experimental_relax_shapes=RELAX_SHAPES
-            )
+            mass = function(mass)
         self._mass = mass
         self._generate_called = False  # not yet called, children can be set
 

--- a/phasespace/phasespace.py
+++ b/phasespace/phasespace.py
@@ -13,7 +13,8 @@ The code is based on the GENBOD function (W515 from CERNLIB), documented in:
 import inspect
 import warnings
 
-from .backend import function, function_jit_fixedshape
+from . import kinematics as kin
+from .backend import function, function_jit_fixedshape, get_shape, tnp
 from .random import SeedLike, generate_uniform, get_rng
 
 RELAX_SHAPES = False
@@ -248,7 +249,7 @@ class GenParticle:
             if n_events is not None:
                 momentum_shape = momentum.shape[0]
                 if momentum_shape is None:
-                    momentum_shape = tf.shape(momentum)[0]
+                    momentum_shape = get_shape(momentum)[0]
                     momentum_shape = tnp.asarray(momentum_shape, tnp.int64)
                 else:
                     momentum_shape = tnp.asarray(momentum_shape, dtype=tnp.int64)
@@ -262,7 +263,7 @@ class GenParticle:
             if len(momentum.shape) == 2:
                 n_events = momentum.shape[0]
                 if n_events is None:  # dynamic shape
-                    n_events = tf.shape(momentum)[0]
+                    n_events = get_shape(momentum)[0]
                     n_events = tnp.asarray(n_events, dtype=tnp.int64)
             else:
                 n_events = tnp.asarray(1, dtype=tnp.int64)
@@ -657,7 +658,7 @@ class GenParticle:
                 f"The number of events requested ({n_events}) doesn't match the boost_to input size "
                 f"of {boost_to.shape}"
             )
-            tf.assert_equal(tf.shape(boost_to)[0], tf.shape(n_events), message=message)
+            tf.assert_equal(len(boost_to), n_events, message=message)
         if not isinstance(n_events, tf.Variable):
             n_events = tnp.asarray(n_events, dtype=tnp.int64)
         weights, weights_max, parts, _ = self._recursive_generate(

--- a/phasespace/phasespace.py
+++ b/phasespace/phasespace.py
@@ -15,6 +15,8 @@ import warnings
 
 from . import kinematics as kin
 from .backend import (
+    Tensor,
+    Variable,
     assert_equal,
     assert_greater_equal,
     function,
@@ -103,7 +105,7 @@ class GenParticle:
         self.name = name
         self.children = []
         self._mass_val = mass
-        if not callable(mass) and not isinstance(mass, tf.Variable):
+        if not callable(mass) and not isinstance(mass, Variable):
             mass = tnp.asarray(mass, dtype=tnp.float64)
         else:
             mass = tf.function(
@@ -138,11 +140,11 @@ class GenParticle:
     @function
     def get_mass(
         self,
-        min_mass: tf.Tensor = None,
-        max_mass: tf.Tensor = None,
-        n_events: Union[tf.Tensor, tf.Variable] = None,
+        min_mass: Tensor = None,
+        max_mass: Tensor = None,
+        n_events: Union[Tensor, Variable] = None,
         seed: SeedLike = None,
-    ) -> tf.Tensor:
+    ) -> Tensor:
         """Get the particle mass.
 
         If the particle is resonant, the mass function will be called with the
@@ -619,11 +621,11 @@ class GenParticle:
 
     def generate(
         self,
-        n_events: Union[int, tf.Tensor, tf.Variable],
-        boost_to: Optional[tf.Tensor] = None,
+        n_events: Union[int, Tensor, Variable],
+        boost_to: Optional[Tensor] = None,
         normalize_weights: bool = True,
         seed: SeedLike = None,
-    ) -> Tuple[tf.Tensor, Dict[str, tf.Tensor]]:
+    ) -> Tuple[Tensor, Dict[str, Tensor]]:
         """Generate normalized n-body phase space as tensorflow tensors.
 
         Any TensorFlow tensor can always be converted to a numpy array with the method `numpy()`.
@@ -666,7 +668,7 @@ class GenParticle:
                 f"of {boost_to.shape}"
             )
             assert_equal(len(boost_to), n_events, message=message)
-        if not isinstance(n_events, tf.Variable):
+        if not isinstance(n_events, Variable):
             n_events = tnp.asarray(n_events, dtype=tnp.int64)
         weights, weights_max, parts, _ = self._recursive_generate(
             n_events=n_events,

--- a/phasespace/random.py
+++ b/phasespace/random.py
@@ -5,16 +5,15 @@ As the random number generation is not a trivial thing, this module handles it u
 It mimicks the TensorFlows API on random generators and relies (currently) in global states on the TF global states.
 Especially on the global random number generator which will be used to get new generators.
 """
-from typing import Optional, Union
 
-import tensorflow as tf
+from typing import Optional, Tuple, Union
 
-from phasespace.backend import random
+from phasespace.backend import random, tnp
 
-SeedLike = Optional[Union[int, tf.random.Generator]]
+SeedLike = Optional[Union[int, random.Generator]]
 
 
-def get_rng(seed: SeedLike = None) -> tf.random.Generator:
+def get_rng(seed: SeedLike = None) -> random.Generator:
     """Get or create a random number generators of type `tf.random.Generator`.
 
     This can be used to either retrieve random number generators deterministically from them
@@ -36,8 +35,17 @@ def get_rng(seed: SeedLike = None) -> tf.random.Generator:
     """
     if seed is None:
         rng = random.default_rng()
-    elif not isinstance(seed, tf.random.Generator):  # it's a seed, not an rng
-        rng = random.Generator.from_seed(seed=seed)
+    elif not isinstance(seed, random.Generator):  # it's a seed, not an rng
+        rng = random.from_seed(seed)
     else:
         rng = seed
     return rng
+
+
+def generate_uniform(
+    rng: random.Generator, shape: Tuple[int, ...], minval=0, maxval=1, dtype=tnp.float64
+) -> tnp.ndarray:
+    try:
+        return rng.uniform(shape, minval=minval, maxval=maxval, dtype=dtype)
+    except TypeError:
+        return rng.uniform(low=minval, high=maxval, size=shape).astype(dtype)

--- a/phasespace/random.py
+++ b/phasespace/random.py
@@ -9,6 +9,8 @@ from typing import Optional, Union
 
 import tensorflow as tf
 
+from phasespace.backend import random
+
 SeedLike = Optional[Union[int, tf.random.Generator]]
 
 
@@ -33,9 +35,9 @@ def get_rng(seed: SeedLike = None) -> tf.random.Generator:
         A list of `tf.random.Generator`
     """
     if seed is None:
-        rng = tf.random.get_global_generator()
+        rng = random.default_rng()
     elif not isinstance(seed, tf.random.Generator):  # it's a seed, not an rng
-        rng = tf.random.Generator.from_seed(seed=seed)
+        rng = random.Generator.from_seed(seed=seed)
     else:
         rng = seed
     return rng

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,3 +7,7 @@ requires = [
 ]
 
 build-backend = "setuptools.build_meta"
+
+[tool.isort]
+profile = "black"
+src_paths = ["phasespace", "tests"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -88,5 +88,6 @@ addopts =
     --ignore=setup.py
 filterwarnings =
     ignore:.*the imp module is deprecated in favour of importlib.*:DeprecationWarning
+    ignore:.*invalid value encountered in true_divide.*:RuntimeWarning
 norecursedirs =
     tests/helpers

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,15 +31,21 @@ packages = find:
 setup_requires =
     setuptools_scm
 install_requires =
-    tensorflow>=2.4,<2.6  # tensorflow.experimental.numpy
-    tensorflow_probability>=0.11,<0.13
+    numpy
 python_requires = >=3.6
 include_package_data = True
 testpaths = tests
 zip_safe = False
 
 [options.extras_require]
+tf =
+    tensorflow>=2.4,<2.6  # tensorflow.experimental.numpy
+    tensorflow_probability>=0.11,<0.13
+tensorflow =
+    %(tf)s
+
 test =
+    %(tf)s
     awkward
     coverage
     flaky

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,7 @@ test =
     numpy
     pytest
     pytest-cov
+    pytest-env
     pytest-xdist
     scipy
     uproot4
@@ -84,6 +85,8 @@ include =
     phasespace/*
 
 [tool:pytest]
+env =
+    D:PHASESPACE_BACKEND=TF
 addopts =
     --ignore=setup.py
 filterwarnings =

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,0 +1,8 @@
+import pytest
+
+from phasespace.backend import BACKEND, BackendType
+
+tf_only = pytest.mark.skipif(
+    BACKEND != BackendType.TENSORFLOW,
+    reason="Test requires tensorflow",
+)

--- a/tests/helpers/decays.py
+++ b/tests/helpers/decays.py
@@ -6,10 +6,13 @@
 # =============================================================================
 """Some physics models to test with."""
 
-import tensorflow as tf
-import tensorflow_probability as tfp
+try:
+    import tensorflow_probability as tfp
+except ImportError:
+    pass
 
 from phasespace import GenParticle
+from phasespace.backend import tnp
 
 # Use RapidSim values (https://github.com/gcowan/RapidSim/blob/master/config/particles.dat)
 B0_MASS = 5279.58
@@ -25,12 +28,12 @@ def b0_to_kstar_gamma(kstar_width=KSTARZ_WIDTH):
     """Generate B0 -> K*gamma."""
 
     def kstar_mass(min_mass, max_mass, n_events):
-        min_mass = tf.cast(min_mass, tf.float64)
-        max_mass = tf.cast(max_mass, tf.float64)
-        kstar_width_cast = tf.cast(kstar_width, tf.float64)
-        kstar_mass_cast = tf.cast(KSTARZ_MASS, dtype=tf.float64)
+        min_mass = tnp.asarray(min_mass, tnp.float64)
+        max_mass = tnp.asarray(max_mass, tnp.float64)
+        kstar_width_cast = tnp.asarray(kstar_width, tnp.float64)
+        kstar_mass_cast = tnp.asarray(KSTARZ_MASS, dtype=tnp.float64)
 
-        kstar_mass = tf.broadcast_to(kstar_mass_cast, shape=(n_events,))
+        kstar_mass = tnp.broadcast_to(kstar_mass_cast, shape=(n_events,))
         if kstar_width > 0:
             kstar_mass = tfp.distributions.TruncatedNormal(
                 loc=kstar_mass, scale=kstar_width_cast, low=min_mass, high=max_mass
@@ -49,11 +52,11 @@ def bp_to_k1_kstar_pi_gamma(k1_width=K1_WIDTH, kstar_width=KSTARZ_WIDTH):
     """Generate B+ -> K1 (-> K* (->K pi) pi) gamma."""
 
     def res_mass(mass, width, min_mass, max_mass, n_events):
-        mass = tf.cast(mass, tf.float64)
-        width = tf.cast(width, tf.float64)
-        min_mass = tf.cast(min_mass, tf.float64)
-        max_mass = tf.cast(max_mass, tf.float64)
-        masses = tf.broadcast_to(mass, shape=(n_events,))
+        mass = tnp.asarray(mass, tnp.float64)
+        width = tnp.asarray(width, tnp.float64)
+        min_mass = tnp.asarray(min_mass, tnp.float64)
+        max_mass = tnp.asarray(max_mass, tnp.float64)
+        masses = tnp.broadcast_to(mass, shape=(n_events,))
         if kstar_width > 0:
             masses = tfp.distributions.TruncatedNormal(
                 loc=masses, scale=width, low=min_mass, high=max_mass

--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -16,7 +16,7 @@ from phasespace import GenParticle
 
 sys.path.append(os.path.dirname(__file__))
 
-from .helpers import decays
+from .helpers import decays, tf_only
 
 
 def test_name_clashes():
@@ -93,6 +93,7 @@ def test_resonance_top():
         kstar.generate(n_events=1)
 
 
+@tf_only
 def test_kstargamma():
     """Test B0 -> K*gamma."""
     decay = decays.b0_to_kstar_gamma()
@@ -104,6 +105,7 @@ def test_kstargamma():
     assert all(part.shape == (1000, 4) for part in particles.values())
 
 
+@tf_only
 def test_k1gamma():
     """Test B+ -> K1 (K*pi) gamma."""
     decay = decays.bp_to_k1_kstar_pi_gamma()

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -29,7 +29,7 @@ from phasespace import phasespace
 
 sys.path.append(os.path.dirname(__file__))
 
-from .helpers import decays, rapidsim
+from .helpers import decays, rapidsim, tf_only
 from .helpers.plotting import make_norm_histo
 
 BASE_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
@@ -268,6 +268,7 @@ def test_kstargamma_kstarnonresonant_lhc():
     assert np.all(p_values > 0.05)
 
 
+@tf_only
 def test_kstargamma_resonant_at_rest():
     """Test B0 -> K* gamma physics with Gaussian mass for K*.
 
@@ -382,6 +383,7 @@ def test_k1gamma_kstarnonresonant_lhc():
     assert np.all(p_values > 0.05)
 
 
+@tf_only
 def test_k1gamma_resonant_at_rest():
     """Test B0 -> K1 (->K*pi) gamma physics.
 

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -22,10 +22,10 @@ import os
 import sys
 
 import matplotlib.pyplot as plt
-import tensorflow as tf
 import uproot4
 
 from phasespace import phasespace
+from phasespace.backend import tnp
 
 sys.path.append(os.path.dirname(__file__))
 
@@ -37,6 +37,8 @@ PLOT_DIR = os.path.join(BASE_PATH, "tests", "plots")
 
 
 def setup_method():
+    import tensorflow as tf
+
     phasespace.GenParticle._sess.close()
     tf.compat.v1.reset_default_graph()
 
@@ -83,7 +85,7 @@ def create_ref_histos(n_pions):
 def run_test(n_particles, test_prefix):
     first_run_n_events = 100
     main_run_n_events = 100000
-    n_events = tf.Variable(initial_value=first_run_n_events, dtype=tf.int64)
+    n_events = tnp.asarray(first_run_n_events, dtype=tnp.int64)
 
     decay = phasespace.nbody_decay(decays.B0_MASS, [decays.PION_MASS] * n_particles)
     generate = decay.generate(n_events)
@@ -91,7 +93,7 @@ def run_test(n_particles, test_prefix):
     assert len(weights1) == first_run_n_events
 
     # change n_events and run again
-    n_events.assign(main_run_n_events)
+    n_events = tnp.asarray(main_run_n_events, dtype=tnp.int64)
     weights, particles = decay.generate(n_events)
     parts = np.concatenate(
         [particles[f"p_{part_num}"] for part_num in range(n_particles)], axis=1

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -1,12 +1,21 @@
 import numpy as np
 import pytest
-import tensorflow as tf
 
 import phasespace as phsp
 
 
+def create_from_seed_input():
+    import tensorflow as tf
+
+    return tf.random.Generator.from_seed(15)
+
+
 @pytest.mark.parametrize(
-    "seed", [lambda: 15, lambda: tf.random.Generator.from_seed(15)]
+    "seed",
+    [
+        lambda: 15,
+        create_from_seed_input,
+    ],
 )
 def test_get_rng(seed):
     rng1 = phsp.random.get_rng(seed())

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -23,16 +23,16 @@ def create_from_seed_input():
 def test_get_rng(seed):
     rng1 = phsp.random.get_rng(seed())
     rng2 = phsp.random.get_rng(seed())
-    rnd1_seeded = rng1.uniform_full_int(shape=(100,))
-    rnd2_seeded = rng2.uniform_full_int(shape=(100,))
+    rnd1_seeded = rng1.uniform(shape=(100,))
+    rnd2_seeded = rng2.uniform(shape=(100,))
 
     rng3 = phsp.random.get_rng()
     rng4 = phsp.random.get_rng(seed())
     # advance rng4 by one step
     _ = rng4.split(1)
 
-    rnd3 = rng3.uniform_full_int(shape=(100,))
-    rnd4 = rng4.uniform_full_int(shape=(100,))
+    rnd3 = rng3.uniform(shape=(100,))
+    rnd4 = rng4.uniform(shape=(100,))
 
     np.testing.assert_array_equal(rnd1_seeded, rnd2_seeded)
     assert not np.array_equal(rnd1_seeded, rnd3)

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -3,6 +3,8 @@ import pytest
 
 import phasespace as phsp
 
+from .helpers import tf_only
+
 
 def create_from_seed_input():
     import tensorflow as tf
@@ -10,6 +12,7 @@ def create_from_seed_input():
     return tf.random.Generator.from_seed(15)
 
 
+@tf_only
 @pytest.mark.parametrize(
     "seed",
     [


### PR DESCRIPTION
Afaics, this setup allows one two switch between `numpy` and `tensorflow` as backend for `phasespace`, resulting in the same distributions. That said, there are some major issues:

- I don't like that one can only switch between backends through an environment variable. I did this mostly to have static typing while developing and to mimic the existing `PHASESPACE_EAGER` variable, but I would prefer to switch the backend dynamically (smt like `phasespace.set_backend("numpy")`).
- Related to that: this `backend` sub-module works, but is emm, not as charming... It originates from the fact that not all TF operations are available in `tensorflow.experimental.numpy`, particularly what `tensorflow.random` offers. So this module provides some kind of mapping (not dynamically :S) for TF functionsm that `phasespace` needs but that are not in the TF numpy API. Some problems with this approach:
    - This `backend.random` 'module' is tightly coupled to `phasespace.random`: change one thing there, and each 'implementation' of `backend.random` has to be adapted as well. In addition, one may wonder whether `phasespace.random.generate_uniform` shouldn't also be put under `backend`.
    - Functions in `backend.random`, as well as `assert_equal`, `shape`, etc follow TensorFlow's interface, whereas we want to move in the direction of `numpy` (assuming `tnp` does as well).
    - This whole setup is not scalable: if you need some other TF (non-`tnp`) functions, you would have to add it to the 'mappings' _for each backend_.
- The backend with numpy is not fully tested: four tests are currently skipped because they requrie TF. The plots that are produced look okay though.
- With regard to the `function` decorators: I had hoped to easily implement JAX as interface as well (and just use `jax.jit` for those functions). This requires more changes though (if possible at all), because JAX can't handle custom classes (here: `GenParticle`).
- I would prefer if one can avoid installing `phasespace` _without_ the rather bulky TF, hence 3bd1f85. This is a breaking change though, as you would now have to use `pip install phasespace[tf]` if you want to keep using TF as backend. Perhaps better to leave this for a follow-up PR, also so that that can be released separately.

I'll leave this a draft PR, so we can think what to do about the above and other issues. Hopefully it's a step in the right direction :)