### PR TITLE
ci: add and enforce flake8 and prettier

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,5 @@
 version: 2
 updates:
-
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@
 
 name: tests
 
-on: [ push ]
+on: [push]
 
 jobs:
   codecov:
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ 3.8 ]
+        python-version: [3.8]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ 3.6, 3.7, 3.9 ]
+        python-version: [3.6, 3.7, 3.9]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -3,34 +3,33 @@
 
 name: Build and deploy
 
-on: [ push ]
+on: [push]
 
 jobs:
   build_deploy:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.x'
-    - name: Install dependencies
-      run: |
-        pip install --upgrade pip
-        pip install setuptools wheel twine
-    - name: Install pep517
-      run: >-
-        pip install pep517
-    - name: Build a binary wheel and a source tarball
-      run: >-
-        python -m
-        pep517.build --source --binary --out-dir dist/ .
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install setuptools wheel twine
+      - name: Install pep517
+        run: >-
+          pip install pep517
+      - name: Build a binary wheel and a source tarball
+        run: >-
+          python -m
+          pep517.build --source --binary --out-dir dist/ .
 
-    - name: Publish package
-      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_PHASESPACE_TOKEN }}
+      - name: Publish package
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_PHASESPACE_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,22 +57,27 @@ repos:
     rev: v2.18.3
     hooks:
       - id: pyupgrade
-        args: [ --py36-plus ]
+        args: [--py36-plus]
 
   - repo: https://github.com/mgedmin/check-manifest
-    rev: '0.46'
+    rev: "0.46"
     hooks:
       - id: check-manifest
-        stages: [ manual ]
+        stages: [manual]
 
   # TODO(py37): add the following once 3.6 is gone. Changes the Type hints.
   # - repo: https://github.com/sondrelg/pep585-upgrade
-  #   rev: '5f7033a0d0174c65105b041500060b993c1bc211'  # Use the sha / tag you want to point at
+  #   rev: "5f7033a0d0174c65105b041500060b993c1bc211" # Use the sha / tag you want to point at
   #   hooks:
   #     - id: upgrade-type-hints
-  #       args: [ '--futures=true' ]
+  #       args: ["--futures=true"]
 
   - repo: https://github.com/psf/black
     rev: 21.5b1
     hooks:
       - id: black
+
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.3.0
+    hooks:
+      - id: prettier

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,9 +20,11 @@ repos:
     rev: v1.4
     hooks:
       - id: docformatter
-        args: [ -r, --in-place, --wrap-descriptions, '120', --wrap-summaries, '120', -- ]
-
-
+        args:
+          - -r
+          - --in-place
+          - --wrap-descriptions=110
+          - --wrap-summaries=110
 
   - repo: https://github.com/mattlqx/pre-commit-sign
     rev: v1.1.3
@@ -36,13 +38,18 @@ repos:
       - id: python-no-eval
       - id: rst-directive-colons
 
+  - repo: https://gitlab.com/PyCQA/flake8
+    rev: 3.9.2
+    hooks:
+      - id: flake8
+
   - repo: https://github.com/PyCQA/isort
     rev: 5.8.0
     hooks:
       - id: isort
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.18.2
+    rev: v2.18.3
     hooks:
       - id: pyupgrade
         args: [ --py36-plus ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,15 @@
 repos:
+  - repo: meta
+    hooks:
+      - id: check-hooks-apply
+      - id: check-useless-excludes
+
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
       - id: check-merge-conflict
-      - id: check-symlinks
       - id: check-yaml
       - id: check-toml
       - id: debug-statements
@@ -30,6 +34,7 @@ repos:
     rev: v1.1.3
     hooks:
       - id: sign-commit
+
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.8.0 # Use the ref you want to point at
     hooks:
@@ -54,28 +59,19 @@ repos:
       - id: pyupgrade
         args: [ --py36-plus ]
 
-  # Notebook formatting
-  - repo: https://github.com/nbQA-dev/nbQA
-    rev: 0.9.0
-    hooks:
-      - id: nbqa-isort
-        additional_dependencies: [ isort==5.6.4 ]
-
-      - id: nbqa-pyupgrade
-        additional_dependencies: [ pyupgrade==2.7.4 ]
-        args: [ --py36-plus ]
-
   - repo: https://github.com/mgedmin/check-manifest
     rev: '0.46'
     hooks:
       - id: check-manifest
         stages: [ manual ]
+
   # TODO(py37): add the following once 3.6 is gone. Changes the Type hints.
-  #  - repo: https://github.com/sondrelg/pep585-upgrade
-  #    rev: '5f7033a0d0174c65105b041500060b993c1bc211'  # Use the sha / tag you want to point at
-  #    hooks:
-  #      - id: upgrade-type-hints
-  #        args: [ '--futures=true' ]
+  # - repo: https://github.com/sondrelg/pep585-upgrade
+  #   rev: '5f7033a0d0174c65105b041500060b993c1bc211'  # Use the sha / tag you want to point at
+  #   hooks:
+  #     - id: upgrade-type-hints
+  #       args: [ '--futures=true' ]
+
   - repo: https://github.com/psf/black
     rev: 21.5b1
     hooks:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -68,7 +68,7 @@ Ready to contribute? Here's how to set up `phasespace` for local development.
 
     $ mkvirtualenv phasespace
     $ cd phasespace/
-    $ python setup.py develop
+    $ pip install -e .[dev]
 
 4. Create a branch for local development::
 
@@ -76,14 +76,11 @@ Ready to contribute? Here's how to set up `phasespace` for local development.
 
    Now you can make your changes locally.
 
-5. When you're done making changes, check that your changes pass flake8 and the
-   tests, including testing other Python versions with tox::
+5. When you're done making changes, check that your changes pass pre-commit and the
+   tests:
 
-    $ flake8 phasespace tests
-    $ python setup.py test or py.test
-    $ tox
-
-   To get flake8 and tox, just pip install them into your virtualenv.
+    $ pytest
+    $ pre-commit run -a
 
 6. Commit your changes and push your branch to GitHub::
 

--- a/benchmark/bench_phasespace.py
+++ b/benchmark/bench_phasespace.py
@@ -8,26 +8,13 @@
 
 import os
 import sys
+from timeit import default_timer
 
 import tensorflow as tf
 
 from phasespace import phasespace
 
 sys.path.append(os.path.dirname(__file__))
-
-# from .monitoring import Timer
-
-# !/usr/bin/env python
-# -*- coding: utf-8 -*-
-# =============================================================================
-# @file   monitoring.py
-# @author Albert Puig (albert.puig@cern.ch)
-# @date   14.02.2017
-# =============================================================================
-"""Various code monitoring utilities."""
-
-import os
-from timeit import default_timer
 
 
 def memory_usage():
@@ -99,8 +86,12 @@ class Timer:
 
 # to play around with optimization, no big effect though
 NUM_PARALLEL_EXEC_UNITS = 1
-# config = tf.ConfigProto(intra_op_parallelism_threads=NUM_PARALLEL_EXEC_UNITS, inter_op_parallelism_threads=1,
-#                         allow_soft_placement=True, device_count={'CPU': NUM_PARALLEL_EXEC_UNITS})
+# config = tf.ConfigProto(
+#     intra_op_parallelism_threads=NUM_PARALLEL_EXEC_UNITS,
+#     inter_op_parallelism_threads=1,
+#     allow_soft_placement=True,
+#     device_count={"CPU": NUM_PARALLEL_EXEC_UNITS},
+# )
 
 B_MASS = 5279.0
 B_AT_REST = tf.stack((0.0, 0.0, 0.0, B_MASS), axis=-1)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,14 +18,7 @@
 # absolute, like shown here.
 #
 
-
-import os
-import sys
-
-sys.path.insert(0, os.path.abspath(".."))
-
 import sphinx_bootstrap_theme
-import tensorflow as tf
 
 import phasespace
 

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -1,5 +1,5 @@
 ---
-title: 'phasespace: $n$-body phase space generation in Python'
+title: "phasespace: $n$-body phase space generation in Python"
 tags:
   - high energy physics
   - tensorflow
@@ -12,8 +12,8 @@ authors:
     orcid: 0000-0002-7312-3699
     affiliation: "1"
 affiliations:
- - name: Physik-Institut, Universität Zürich, Zürich (Switzerland)
-   index: 1
+  - name: Physik-Institut, Universität Zürich, Zürich (Switzerland)
+    index: 1
 date: 3 June 2019
 bibliography: paper.bib
 ---
@@ -25,21 +25,21 @@ They are used to study a wide variety of aspects of a physics analysis, such as 
 While it is possible to encode complex physics dynamics into these simulations at the cost of increased complexity and larger computer requirements, in many cases it is enough to generate these simulated samples as if only kinematic physics occurred, i.e., in an isotropic way.
 This type of generation, called "phase space generation", is very fast and offers simple and predictable patterns, making it an attractive first step in many physics analyses.
 
-The ``phasespace`` package implements phase space event generation based on the Raubold and Lynch method described in [@James:1968gu].
-This method was previously implemented in the ``GENBOD`` function of the FORTRAN-based ``CERNLIB`` library. It was posteriorly ported to C++ for the ROOT toolkit [@Brun:1997pa] as the ``TGenPhaseSpace`` class, which is currently the most used implementation in particle physics.
-The ``phasespace`` package provides a pure Python implementation of the Raubold and Lynch method using the *Tensorflow* platform [@tensorflow2015-whitepaper] as its computational backend.
-Unlike ``TGenPhaseSpace``, the ``phasespace`` approach offers seamless integration with the scientific Python ecosystem (*numpy*, *pandas*, *scikit-learn*...) while at the same time provides excellent performance and scalability both in CPUs and GPUs thanks to *Tensorflow*.
+The `phasespace` package implements phase space event generation based on the Raubold and Lynch method described in [@James:1968gu].
+This method was previously implemented in the `GENBOD` function of the FORTRAN-based `CERNLIB` library. It was posteriorly ported to C++ for the ROOT toolkit [@Brun:1997pa] as the `TGenPhaseSpace` class, which is currently the most used implementation in particle physics.
+The `phasespace` package provides a pure Python implementation of the Raubold and Lynch method using the _Tensorflow_ platform [@tensorflow2015-whitepaper] as its computational backend.
+Unlike `TGenPhaseSpace`, the `phasespace` approach offers seamless integration with the scientific Python ecosystem (_numpy_, _pandas_, _scikit-learn_...) while at the same time provides excellent performance and scalability both in CPUs and GPUs thanks to _Tensorflow_.
 
-In addition, ``phasespace`` allows the generation of complex multi-decay chains, including non-constant masses as is needed for the simulation of resonant particles.
-This functionality opens the door for its use as the basis for importance sampling in Dalitz and amplitude decay fitters, which typically need to implement their own solution based on ``TGenPhaseSpace``;
-in this sense, ``phasespace`` is currently being used for the implementation of amplitude fit sampling in the ``zfit`` fitter [@zfit].
+In addition, `phasespace` allows the generation of complex multi-decay chains, including non-constant masses as is needed for the simulation of resonant particles.
+This functionality opens the door for its use as the basis for importance sampling in Dalitz and amplitude decay fitters, which typically need to implement their own solution based on `TGenPhaseSpace`;
+in this sense, `phasespace` is currently being used for the implementation of amplitude fit sampling in the `zfit` fitter [@zfit].
 
-The correctness of ``phasespace`` is continuously validated through its test suite against ``TGenPhaseSpace`` and the ``RapidSim`` package [@Cowan:2016tnm], an application for the simulation of heavy-quark hadron decays;
-this latter application also uses ``TGenPhaseSpace``, but adds features such as multi-decay chains and simulation of the kinematics found in colliders such as the LHC.
+The correctness of `phasespace` is continuously validated through its test suite against `TGenPhaseSpace` and the `RapidSim` package [@Cowan:2016tnm], an application for the simulation of heavy-quark hadron decays;
+this latter application also uses `TGenPhaseSpace`, but adds features such as multi-decay chains and simulation of the kinematics found in colliders such as the LHC.
 
-In summary, ``phasespace`` is designed to fill an important gap in the recent paradigm shift of particle physics analysis towards integration with the scientific Python ecosystem. To do so it also has more advanced functionality than its C++-based predecessors.
-With its ease of use, clear interface and direct interoperability with other packages, ``phasespace`` provides a solid foundation to build upon in the quest for a full Python-based particle physics analysis software stack.
-The source code for ``phasespace`` has been archived to Zenodo with the linked DOI: [@zenodo].
+In summary, `phasespace` is designed to fill an important gap in the recent paradigm shift of particle physics analysis towards integration with the scientific Python ecosystem. To do so it also has more advanced functionality than its C++-based predecessors.
+With its ease of use, clear interface and direct interoperability with other packages, `phasespace` provides a solid foundation to build upon in the quest for a full Python-based particle physics analysis software stack.
+The source code for `phasespace` has been archived to Zenodo with the linked DOI: [@zenodo].
 
 # Acknowledgements
 

--- a/phasespace/__init__.py
+++ b/phasespace/__init__.py
@@ -12,6 +12,9 @@ __all__ = ["nbody_decay", "GenParticle", "random"]
 
 import tensorflow as tf
 
+from . import random
+from .phasespace import GenParticle, nbody_decay
+
 
 def _set_eager_mode():
     import os
@@ -21,6 +24,3 @@ def _set_eager_mode():
 
 
 _set_eager_mode()
-
-from . import random
-from .phasespace import GenParticle, nbody_decay

--- a/phasespace/phasespace.py
+++ b/phasespace/phasespace.py
@@ -12,12 +12,6 @@ The code is based on the GENBOD function (W515 from CERNLIB), documented in:
 """
 import inspect
 import warnings
-
-from .backend import function, function_jit_fixedshape
-from .random import SeedLike, get_rng
-
-RELAX_SHAPES = False
-
 from math import pi
 from typing import Callable, Dict, Optional, Tuple, Union
 
@@ -25,6 +19,10 @@ import tensorflow as tf
 import tensorflow.experimental.numpy as tnp
 
 from . import kinematics as kin
+from .backend import function, function_jit_fixedshape
+from .random import SeedLike, get_rng
+
+RELAX_SHAPES = False
 
 
 def process_list_to_tensor(lst):
@@ -513,7 +511,8 @@ class GenParticle:
 
         Raise:
             tf.errors.InvalidArgumentError: If the the decay is kinematically forbidden.
-            ValueError: If `n_events` and the size of `boost_to` don't match. See `GenParticle.generate_unnormalized`.
+            ValueError: If `n_events` and the size of `boost_to` don't match.
+            See `GenParticle.generate_unnormalized`.
         """
         if boost_to is not None:
             momentum = boost_to
@@ -648,7 +647,8 @@ class GenParticle:
 
         Raise:
             tf.errors.InvalidArgumentError: If the the decay is kinematically forbidden.
-            ValueError: If `n_events` and the size of `boost_to` don't match. See `GenParticle.generate_unnormalized`.
+            ValueError: If `n_events` and the size of `boost_to` don't match.
+            See `GenParticle.generate_unnormalized`.
         """
         rng = get_rng(seed)
         if boost_to is not None:
@@ -706,7 +706,8 @@ class GenParticle:
 
         Raise:
             tf.errors.InvalidArgumentError: If the the decay is kinematically forbidden.
-            ValueError: If `n_events` and the size of `boost_to` don't match. See `GenParticle.generate_unnormalized`.
+            ValueError: If `n_events` and the size of `boost_to` don't match.
+            See `GenParticle.generate_unnormalized`.
         """
 
         # Run generation

--- a/phasespace/random.py
+++ b/phasespace/random.py
@@ -2,7 +2,7 @@
 
 As the random number generation is not a trivial thing, this module handles it uniformly.
 
-It mimicks the TensorFlows API on random generators and relies (currently) in global states on the TF global states.
+It mimicks the TensorFlows API on random generators and relies (currently) in global states on the TF states.
 Especially on the global random number generator which will be used to get new generators.
 """
 from typing import Optional, Union

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,3 +7,7 @@ requires = [
 ]
 
 build-backend = "setuptools.build_meta"
+
+[tool.isort]
+profile = "black"
+src_paths = ["phasespace", "tests"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -85,6 +85,7 @@ include =
 
 [tool:pytest]
 addopts =
+    --color=yes
     --ignore=setup.py
 filterwarnings =
     ignore:.*the imp module is deprecated in favour of importlib.*:DeprecationWarning

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,7 +58,7 @@ dev =
     %(doc)s
     %(test)s
     bumpversion
-    flake8
+    pre-commit
     twine
     watchdog
 

--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -16,7 +16,7 @@ from phasespace import GenParticle
 
 sys.path.append(os.path.dirname(__file__))
 
-from .helpers import decays
+from .helpers import decays  # noqa: E402
 
 
 def test_name_clashes():

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -16,7 +16,7 @@ import phasespace
 
 sys.path.append(os.path.dirname(__file__))
 
-from .helpers import decays
+from .helpers import decays  # noqa: E402
 
 B0_MASS = decays.B0_MASS
 PION_MASS = decays.PION_MASS

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -29,8 +29,8 @@ from phasespace import phasespace
 
 sys.path.append(os.path.dirname(__file__))
 
-from .helpers import decays, rapidsim
-from .helpers.plotting import make_norm_histo
+from .helpers import decays, rapidsim  # noqa: E402
+from .helpers.plotting import make_norm_histo  # noqa: E402
 
 BASE_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 PLOT_DIR = os.path.join(BASE_PATH, "tests", "plots")
@@ -271,9 +271,9 @@ def test_kstargamma_kstarnonresonant_lhc():
 def test_kstargamma_resonant_at_rest():
     """Test B0 -> K* gamma physics with Gaussian mass for K*.
 
-    Since we don't have BW and we model the resonances with Gaussians, we can't really perform the Kolmogorov test wrt
-    to RapidSim, so plots are generated and can be inspected by the user. However, small differences are expected in the
-    tails of the energy distributions of the kaon and the pion.
+    Since we don't have BW and we model the resonances with Gaussians, we can't really perform the Kolmogorov
+    test wrt to RapidSim, so plots are generated and can be inspected by the user. However, small differences
+    are expected in the tails of the energy distributions of the kaon and the pion.
     """
     run_kstargamma(
         "B2KstGamma_RapidSim_7TeV_Tree.root", decays.KSTARZ_WIDTH, True, "Gaussian"
@@ -385,8 +385,8 @@ def test_k1gamma_kstarnonresonant_lhc():
 def test_k1gamma_resonant_at_rest():
     """Test B0 -> K1 (->K*pi) gamma physics.
 
-    Since we don't have BW and we model the resonances with Gaussians, we can't really perform the Kolmogorov test wrt
-    to RapidSim, so plots are generated and can be inspected by the user.
+    Since we don't have BW and we model the resonances with Gaussians, we can't really perform the Kolmogorov
+    test wrt to RapidSim, so plots are generated and can be inspected by the user.
     """
     run_k1_gamma(
         "B2K1Gamma_RapidSim_7TeV_Tree.root",


### PR DESCRIPTION
Noticed that `flake8` is listed as a dev dependency, but is not enforce. This fixes that.

While I was at it, I added [Prettier](https://prettier.io) as a hook to format markdown, yaml etc. and cleaned up the pre-commit config with some meta hooks.