### PR TITLE
fix: require at least TF 2.5

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ packages = find:
 setup_requires =
     setuptools_scm
 install_requires =
-    tensorflow>=2.4,<2.6  # tensorflow.experimental.numpy
+    tensorflow>=2.5,<2.6  # tensorflow.experimental.numpy
     tensorflow_probability>=0.11,<0.13
 python_requires = >=3.6
 include_package_data = True


### PR DESCRIPTION
Actually, some tests would fail on TF 2.4 but due to a glitch this was not detected. Pinning it to at least 2.5