### PR TITLE
drop Python 3.6 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.9]
+        python-version: [3.7, 3.9]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Bug fixes and small changes
 
 Requirement changes
 -------------------
+- drop Python 3.6 support
 
 
 Thanks

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,6 @@ classifiers =
     Operating System :: Unix
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -33,7 +32,7 @@ setup_requires =
 install_requires =
     tensorflow>=2.5,<2.8  # tensorflow.experimental.numpy
     tensorflow_probability>=0.11
-python_requires = >=3.6
+python_requires = >=3.7
 include_package_data = True
 testpaths = tests
 zip_safe = False


### PR DESCRIPTION
End of live is in December, so we can drop it (it's causing issues in #63 as dependencies dropped 3.6 already)
@redeboer is that fine? I assume that tensorwaves will also soon drop it?