### PR TITLE
Make `vector` package optional

### DIFF
--- a/phasespace/phasespace.py
+++ b/phasespace/phasespace.py
@@ -17,7 +17,7 @@ import functools
 import inspect
 from collections.abc import Callable
 from math import pi
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NoReturn
 
 import numpy as np
 import tensorflow as tf
@@ -676,10 +676,7 @@ class GenParticle:
             try:
                 import vector
             except ImportError as error:
-                raise ImportError(
-                    "To use `boost_to`, the `vector` package has to be installed."
-                ) from error
-
+                _raise_missing_vector_package(error)
             if isinstance(boost_to, vector.Vector):
                 if not (
                     isinstance(boost_to, vector.Momentum)
@@ -826,8 +823,18 @@ def to_vectors(particles: dict[str, tf.Tensor]) -> dict[str, vector.Momentum]:
     Return:
         dict: Dictionary of `vector.Momentum` instances with numpy arrays
     """
+    try:
+        import vector
+    except ImportError as error:
+        _raise_missing_vector_package(error)
     newparticles = {}
     for name, particle in particles.items():
         px, py, pz, e = np.moveaxis(particle, -1, 0)  # numpy "unstack"
         newparticles[name] = vector.array(dict(px=px, py=py, pz=pz, energy=e))
     return newparticles
+
+
+def _raise_missing_vector_package(exception: ImportError) -> NoReturn:
+    raise ImportError(
+        "To use `boost_to`, the `vector` package has to be installed."
+    ) from exception

--- a/phasespace/phasespace.py
+++ b/phasespace/phasespace.py
@@ -17,15 +17,19 @@ import functools
 import inspect
 from collections.abc import Callable
 from math import pi
+from typing import TYPE_CHECKING
 
 import numpy as np
 import tensorflow as tf
 import tensorflow.experimental.numpy as tnp
-import vector
 
 from . import kinematics as kin
 from .backend import function, function_jit_fixedshape
 from .random import SeedLike, get_rng
+
+if TYPE_CHECKING:
+    import vector
+
 
 RELAX_SHAPES = False
 
@@ -669,6 +673,13 @@ class GenParticle:
         """
         rng = get_rng(seed)
         if boost_to is not None:
+            try:
+                import vector
+            except ImportError as error:
+                raise ImportError(
+                    "To use `boost_to`, the `vector` package has to be installed."
+                ) from error
+
             if isinstance(boost_to, vector.Vector):
                 if not (
                     isinstance(boost_to, vector.Momentum)


### PR DESCRIPTION
Seems that the `vector` package is an optional dependency:
https://github.com/zfit/phasespace/blob/f6db1e00702ce7259c0d0f10eb3833d0992e2e5a/setup.cfg#L52-L53

but it is still required for `import phasespace`:

https://github.com/zfit/phasespace/blob/1d83735c77ed1b017027325398495483e9aed516/phasespace/phasespace.py#L24

What do you think about importing it only for type checking?